### PR TITLE
Fix: Restore attn1/attn2 in remove_patch, add recommended remove_patch statement in callback

### DIFF
--- a/agentsd/patch.py
+++ b/agentsd/patch.py
@@ -17,7 +17,6 @@ from .utils import isinstance_str, init_generator
 from torch import nn, einsum
 from einops import rearrange, repeat
 from inspect import isfunction
-import modules.sd_hijack
 
 
 def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable, ...]:

--- a/scripts/agat.py
+++ b/scripts/agat.py
@@ -199,6 +199,7 @@ class AgentAttentionExtensionScript(scripts.Script):
                 sampling_step = params.sampling_step
 
                 if sampling_step == 0:
+                        self.remove_patch()
                         self.apply_patch(sx=sx, sy=sy, ratio=ratio, agent_ratio=agent_ratio, use_fp32=use_fp32, max_downsample=max_downsample)
 
                 if sampling_step == sp_step:


### PR DESCRIPTION
Partially addresses #3

Previously, remove_patch() did not restore the class value of attn1/attn2. We store the old value and restore in remove_patch. 
